### PR TITLE
Upgrade AWS SDK go

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,9 +2,58 @@
 
 
 [[projects]]
+  digest = "1:0282b253b2bfb86a55e3ab6c6a2ddaea8852a3c0fc8121a8c9a6ff6efd3a352b"
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/s3/s3iface","service/s3/s3manager","service/s3/s3manager/s3manageriface","service/sts"]
-  revision = "d46843b92a3a8e377d7fe24b4d70fca37f923d00"
+  packages = [
+    "aws",
+    "aws/arn",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/context",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
+    "private/checksum",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/s3/internal/arn",
+    "service/s3/s3iface",
+    "service/s3/s3manager",
+    "service/s3/s3manager/s3manageriface",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = ""
+  revision = "8e96fdf94cdefd46f17f156bfb1a6d251e99fdee"
   version = "v1.31.15"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   name = "github.com/aws/aws-sdk-go"
   packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/s3","service/s3/s3iface","service/s3/s3manager","service/s3/s3manager/s3manageriface","service/sts"]
   revision = "d46843b92a3a8e377d7fe24b4d70fca37f923d00"
-  version = "v1.12.22"
+  version = "v1.31.15"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,5 +1,6 @@
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
+  version = "v1.31.15"
 
 [[constraint]]
   name = "github.com/pkg/errors"


### PR DESCRIPTION
To be able to use IAM role for Service Accounts in EKS we need a more recent version of aws sdk for go.

This PR upgrades envvault to the last AWS SDK go version.